### PR TITLE
feat: add tests for map tiles

### DIFF
--- a/src/aws/osml/integ/endpoints/__init__.py
+++ b/src/aws/osml/integ/endpoints/__init__.py
@@ -7,6 +7,7 @@ from .test_describe_viewpoint import describe_viewpoint, describe_viewpoint_inva
 from .test_get_bounds import get_bounds, get_bounds_invalid
 from .test_get_crop import get_crop, get_crop_invalid
 from .test_get_info import get_info, get_info_invalid
+from .test_get_map_tile import get_map_tile, get_map_tileset_metadata, get_map_tilesets
 from .test_get_metadata import get_metadata, get_metadata_invalid
 from .test_get_preview import get_preview, get_preview_invalid
 from .test_get_statistics import get_statistics, get_statistics_invalid

--- a/src/aws/osml/integ/endpoints/test_get_bounds.py
+++ b/src/aws/osml/integ/endpoints/test_get_bounds.py
@@ -13,7 +13,7 @@ def get_bounds(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/bounds")
+    res = session.get(f"{url}/{viewpoint_id}/image/bounds")
     res.raise_for_status()
 
     response_data = res.json()
@@ -32,7 +32,7 @@ def get_bounds_invalid(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/bounds")
+    res = session.get(f"{url}/{viewpoint_id}/image/bounds")
 
     response_data = res.json()
 

--- a/src/aws/osml/integ/endpoints/test_get_crop.py
+++ b/src/aws/osml/integ/endpoints/test_get_crop.py
@@ -13,7 +13,7 @@ def get_crop(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/crop/32,32,64,64.PNG")
+    res = session.get(f"{url}/{viewpoint_id}/image/crop/32,32,64,64.PNG")
     res.raise_for_status()
 
     assert res.status_code == 200
@@ -31,7 +31,7 @@ def get_crop_invalid(session: Session, url: str, viewpoint_id: str) -> None:
     return: None
     """
 
-    res = session.get(f"{url}/{viewpoint_id}/crop/32,32,64,64.PNG")
+    res = session.get(f"{url}/{viewpoint_id}/image/crop/32,32,64,64.PNG")
 
     response_data = res.json()
 

--- a/src/aws/osml/integ/endpoints/test_get_info.py
+++ b/src/aws/osml/integ/endpoints/test_get_info.py
@@ -13,7 +13,7 @@ def get_info(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/info")
+    res = session.get(f"{url}/{viewpoint_id}/image/info")
     res.raise_for_status()
 
     assert res.status_code == 200
@@ -29,7 +29,7 @@ def get_info_invalid(session: Session, url: str, viewpoint_id: str) -> None:
 
     return : None
     """
-    res = session.get(f"{url}/{viewpoint_id}/info")
+    res = session.get(f"{url}/{viewpoint_id}/image/info")
 
     response_data = res.json()
 

--- a/src/aws/osml/integ/endpoints/test_get_map_tile.py
+++ b/src/aws/osml/integ/endpoints/test_get_map_tile.py
@@ -1,0 +1,55 @@
+#  Copyright 2024 Amazon.com, Inc. or its affiliates.
+
+from requests import Session
+
+
+def get_map_tilesets(session: Session, url: str, viewpoint_id: str) -> None:
+    """
+    Test Case: Successfully get a list of tilesets supported by a viewpoint
+
+    :param session: Requests session to use to send the request.
+    :param url: URL to send the request to.
+    :param viewpoint_id: Unique viewpoint id to get from the table.
+
+    return: None
+    """
+    res = session.get(f"{url}/{viewpoint_id}/map/tiles")
+    res.raise_for_status()
+
+    assert res.status_code == 200
+    assert res.headers.get("content-type") == "application/json"
+
+
+def get_map_tileset_metadata(session: Session, url: str, viewpoint_id: str, tileset_id: str) -> None:
+    """
+    Test Case: Successfully get a the metadata for a tileset
+
+    :param session: Requests session to use to send the request.
+    :param url: URL to send the request to.
+    :param viewpoint_id: Unique viewpoint id to get from the table.
+    :param tileset_id: ID of the tileset to get metadata for
+
+    return: None
+    """
+    res = session.get(f"{url}/{viewpoint_id}/map/tiles/{tileset_id}")
+    res.raise_for_status()
+
+    assert res.status_code == 200
+    assert res.headers.get("content-type") == "application/json"
+
+
+def get_map_tile(session: Session, url: str, viewpoint_id: str) -> None:
+    """
+    Test Case: Successfully get a map tile of the viewpoint
+
+    :param session: Requests session to use to send the request.
+    :param url: URL to send the request to.
+    :param viewpoint_id: Unique viewpoint id to get from the table.
+
+    return: None
+    """
+    res = session.get(f"{url}/{viewpoint_id}/map/tiles/WebMercatorQuad/0/0/0.PNG")
+    res.raise_for_status()
+
+    assert res.status_code == 200
+    assert res.headers.get("content-type") == "image/png"

--- a/src/aws/osml/integ/endpoints/test_get_metadata.py
+++ b/src/aws/osml/integ/endpoints/test_get_metadata.py
@@ -13,7 +13,7 @@ def get_metadata(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/metadata")
+    res = session.get(f"{url}/{viewpoint_id}/image/metadata")
     res.raise_for_status()
 
     response_data = res.json()
@@ -32,7 +32,7 @@ def get_metadata_invalid(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session("GET", f"{url}/{viewpoint_id}/metadata")
+    res = session("GET", f"{url}/{viewpoint_id}/image/metadata")
 
     response_data = res.json()
 

--- a/src/aws/osml/integ/endpoints/test_get_preview.py
+++ b/src/aws/osml/integ/endpoints/test_get_preview.py
@@ -13,7 +13,7 @@ def get_preview(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/preview.JPEG")
+    res = session.get(f"{url}/{viewpoint_id}/image/preview.JPEG")
     res.raise_for_status()
 
     assert res.status_code == 200
@@ -30,7 +30,7 @@ def get_preview_invalid(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/preview.JPEG")
+    res = session.get(f"{url}/{viewpoint_id}/image/preview.JPEG")
 
     response_data = res.json()
 

--- a/src/aws/osml/integ/endpoints/test_get_statistics.py
+++ b/src/aws/osml/integ/endpoints/test_get_statistics.py
@@ -13,7 +13,7 @@ def get_statistics(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/statistics")
+    res = session.get(f"{url}/{viewpoint_id}/image/statistics")
     res.raise_for_status()
 
     response_data = res.json()
@@ -35,7 +35,7 @@ def get_statistics_invalid(session: Session, url: str, viewpoint_id: str) -> Non
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/statistics")
+    res = session.get(f"{url}/{viewpoint_id}/image/statistics")
 
     response_data = res.json()
 

--- a/src/aws/osml/integ/endpoints/test_get_tile.py
+++ b/src/aws/osml/integ/endpoints/test_get_tile.py
@@ -13,7 +13,7 @@ def get_tile(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/tiles/10/10/10.PNG")
+    res = session.get(f"{url}/{viewpoint_id}/image/tiles/10/10/10.PNG")
     res.raise_for_status()
 
     assert res.status_code == 200
@@ -30,7 +30,7 @@ def get_tile_invalid(session: Session, url: str, viewpoint_id: str) -> None:
 
     return: None
     """
-    res = session.get(f"{url}/{viewpoint_id}/tiles/10/10/10.PNG")
+    res = session.get(f"{url}/{viewpoint_id}/image/tiles/10/10/10.PNG")
 
     response_data = res.json()
 

--- a/src/aws/osml/integ/test_tile_server.py
+++ b/src/aws/osml/integ/test_tile_server.py
@@ -18,6 +18,9 @@ from .endpoints import (
     get_bounds,
     get_crop,
     get_info,
+    get_map_tile,
+    get_map_tileset_metadata,
+    get_map_tilesets,
     get_metadata,
     get_preview,
     get_statistics,
@@ -82,6 +85,9 @@ class TestTileServer:
         self.test_get_preview()
         self.test_get_tile()
         self.test_get_crop()
+        self.test_get_map_tilesets()
+        self.test_get_map_tileset_metadata()
+        self.test_get_map_tile()
         self.test_delete_viewpoint()
         test_summary = self._pretty_print_test_results(self.test_results)
         if TestResult.FAILED in self.test_results.values():
@@ -223,6 +229,36 @@ class TestTileServer:
             logging.info(f"\tFailed. {err}")
             logging.error(traceback.print_exception(err))
             self.test_results["Get Crop"] = TestResult.FAILED
+
+    def test_get_map_tilesets(self) -> None:
+        try:
+            logging.info("Testing get map tilesets")
+            get_map_tilesets(self.session, self.viewpoints_url, self.viewpoint_id)
+            self.test_results["Get Map Tilesets"] = TestResult.PASSED
+        except Exception as err:
+            logging.info(f"\tFailed. {err}")
+            logging.error(traceback.print_exception(err))
+            self.test_results["Get Map Tilesets"] = TestResult.FAILED
+
+    def test_get_map_tileset_metadata(self) -> None:
+        try:
+            logging.info("Testing get map tileset metadata")
+            get_map_tileset_metadata(self.session, self.viewpoints_url, self.viewpoint_id, "WebMercatorQuad")
+            self.test_results["Get Map Tileset Metadata"] = TestResult.PASSED
+        except Exception as err:
+            logging.info(f"\tFailed. {err}")
+            logging.error(traceback.print_exception(err))
+            self.test_results["Get Map Tileset Metadata"] = TestResult.FAILED
+
+    def test_get_map_tile(self) -> None:
+        try:
+            logging.info("Testing get map tile")
+            get_map_tile(self.session, self.viewpoints_url, self.viewpoint_id)
+            self.test_results["Get Map Tile"] = TestResult.PASSED
+        except Exception as err:
+            logging.info(f"\tFailed. {err}")
+            logging.error(traceback.print_exception(err))
+            self.test_results["Get Map Tile"] = TestResult.FAILED
 
     def test_delete_viewpoint(self) -> None:
         try:

--- a/src/aws/osml/load/load_test.py
+++ b/src/aws/osml/load/load_test.py
@@ -7,10 +7,13 @@ import subprocess
 def run_load_test(locust_run_time: str = "") -> None:
     log_run_config = f"for {locust_run_time}" if locust_run_time else "UI on http://localhost:8089"
     logging.info(f"Running Tile Server locust load test {log_run_config}")
-    result = subprocess.run("locust", capture_output=True)
-    locust_exit_code = result.returncode
-    locust_output = f"{result.stdout.decode()}{result.stderr.decode()}"
+
+    child_process = subprocess.Popen("locust", stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    with child_process.stdout:
+        for line in iter(child_process.stdout.readline, b"\n"):
+            logging.info(line)
+    locust_exit_code = child_process.returncode
     if locust_exit_code:
-        raise RuntimeError(f"{locust_output}\n\rExit code: {locust_exit_code}.")
+        raise RuntimeError(f"Exit code: {locust_exit_code}.")
     else:
-        logging.info(f"{locust_output}\n\rLoad test succeeded with exit code: {locust_exit_code}.")
+        logging.info(f"Load test succeeded with exit code: {locust_exit_code}.")

--- a/src/aws/osml/run_test.py
+++ b/src/aws/osml/run_test.py
@@ -45,6 +45,7 @@ def set_load_test_env(args: Dict) -> None:
     # custom Locus params
     os.environ["LOCUST_TEST_IMAGES_BUCKET"] = args.get("source_image_bucket", "")
     os.environ["LOCUST_TEST_IMAGE_KEYS"] = json.dumps(args.get("locust_image_keys", []))
+    logging.info(f"Setup Locust Test Environment: {os.environ}")
 
 
 def lambda_get_next(lambda_runtime_api: str, function_name: str) -> Tuple[Dict, Dict]:


### PR DESCRIPTION
These updates add integration and load tests to exercise the new tile server map tiles APIs. The key updates are as follows:
- The URL paths for existing integration and load tests have been updated to include `/image` which was added to differentiate those APIs from the new map APIs.
- New integration tests have been added to exercise the endpoints that list tilesets for a viewpoint, get metadata about a specific viewpoint tileset, and create tiles from a tileset. These three tests have been added to the sequence of tests run on an image.
- A new load test behavior has been added to simulate a user retrieving map tiles. This test selects a random image from the test images bucket, uses the endpoints to describe the tilesets to determine what tiles can be created from the image and it then requests those tiles from the map tiles API. 

During the development of these load tests some problems were uncovered with the current load test integration into the test framework. In particular the parameter for the test images array was not being processed correctly which prevented any load tests from being run. This necessitated the following updates:
- The code to launch locust as a subprocess was updated to pipe outputs from that process to STDOUT. This allowed me to get insights into where the problems were with running tests.
- The code that converts parameters from run_test.py into environment variables and eventually into locust parameters was updated to pass the JSON encoded array correctly. This code still seems unnecessarily complex and it likely deserves some rework but this was a minimal change necessary to execute the new tests added as part of this PR.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
