### PR TITLE
chore: update integ dockerfile

### DIFF
--- a/docker/Dockerfile.integ
+++ b/docker/Dockerfile.integ
@@ -1,6 +1,6 @@
 # Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
 
-FROM public.ecr.aws/lambda/python:3.11 AS integ
+FROM public.ecr.aws/lambda/python:3.13 AS integ
 
 # Build time arguments
 ARG BUILD_CERT=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
@@ -15,11 +15,11 @@ ARG PACKAGES="wget"
 # Give sudo permissions
 USER root
 
-# Configure, update, and refresh yum environment
-RUN yum update -y && yum clean all && yum makecache
+# Configure, update, and refresh dnf environment
+RUN dnf update -y && dnf clean all && dnf makecache
 
 # Install all our dependencies
-RUN yum install -y $PACKAGES
+RUN dnf install -y $PACKAGES
 
 # Install Miniconda
 RUN wget -c ${MINICONDA_URL} && \
@@ -47,7 +47,7 @@ ENV PATH=/opt/conda/envs/${CONDA_ENV_NAME}/bin/:$PATH
 ENV PYTHONPATH=/opt/conda/envs/${CONDA_ENV_NAME}/bin
 
 # We now replace the image’s existing Python with Python from the conda environment:
-RUN mv /var/lang/bin/python3.11 /var/lang/bin/python3.11-clean && ln -sf /opt/conda/envs/${CONDA_ENV_NAME}/bin/python /var/lang/bin/python3.11
+RUN mv /var/lang/bin/python3.13 /var/lang/bin/python3.13-clean && ln -sf /opt/conda/envs/${CONDA_ENV_NAME}/bin/python /var/lang/bin/python3.13
 
 # Clean up any dangling conda resources
 RUN conda clean -afy


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Update amazon/aws-lambda-python image to python:3.13. Latest Miniconda3-latest-Linux-x86_64 requires newer glibc version. The update requires switching to dnf from yum.

### Files Changed
- `docker.Dockerfile.integ`

### Testing
- Deployed updates to test account, tile server integration tests passing.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
